### PR TITLE
fix: fall back if bounds-of-thing-at-point is nil

### DIFF
--- a/consult-yasnippet.el
+++ b/consult-yasnippet.el
@@ -82,7 +82,8 @@ is t."
                     (or (string-match-p thing (regexp-quote (yas--template-key template)))
                         (string-match-p thing (regexp-quote (yas--template-name template))))))))
         (if use-thing-at-point
-            (bounds-of-thing-at-point 'symbol)
+            (or (bounds-of-thing-at-point 'symbol)
+                (cons (point) (point)))
           (cons (point) (point))))
     (cons (point) (point))))
 


### PR DESCRIPTION
This fixes an error when `bounds-of-thing-at-point` returns nil, which can happen when the point is on an empty line.

This fixes issue #13. Well sort of. I don't think that issue is reproducible any longer so it must've been Emacs30-related. This on the other hand is a fix and it does make sense.