### PR TITLE
feature: Add support for grouping candidates

### DIFF
--- a/consult-yasnippet.el
+++ b/consult-yasnippet.el
@@ -144,18 +144,20 @@ this function removes the matching prefix from the preview."
   "Convert TEMPLATES into candidates for `completing-read'."
   (mapcar
    (lambda (template)
-     (cons (concat
-            (propertize (concat (yas--table-name (yas--template-table template))
-                                " ")
-                        'invisible t)
-            (yas--template-name template)
-            " ["
-            (propertize (or (yas--template-key template)
-                            (and (functionp 'yas--template-regexp-key)
-                                 (yas--template-regexp-key template)))
-                        'face 'consult-key)
-            "]")
-           template))
+     (let* ((group-list (cons (yas--table-name (yas--template-table template))
+                              (yas--template-group template)))
+            (group-name (string-join (or (cdr group-list) group-list) "/")))
+       (cons (concat
+              (propertize group-name 'consult--prefix-group group-name)
+              " "
+              (yas--template-name template)
+              " ["
+              (propertize (or (yas--template-key template)
+                              (and (functionp 'yas--template-regexp-key)
+                                   (yas--template-regexp-key template)))
+                          'face 'consult-key)
+              "]")
+             template)))
    templates))
 
 (defun consult-yasnippet--annotate (candidates)
@@ -198,6 +200,7 @@ returns a snippet template from the user."
      :lookup 'consult--lookup-cdr
      :require-match t
      :state (consult-yasnippet--preview)
+     :group 'consult--prefix-group
      :category 'yasnippet)))
 
 ;;;###autoload


### PR DESCRIPTION
- To group or narrow down candidates, each one has a group name as a prefix.  The "consult--prefix-group" property is given to this group name.

- The default group name will be the same as the snippet's table name, as before. If snippet's menu grouping is enabled(e.g., # group: directive or .yas-make-groups file), the group name will be the menu group name, separated by a slash.

![スクリーンショット 2025-04-10 212408](https://github.com/user-attachments/assets/536559ae-bf28-4e2d-9a2c-470dd0852f15)
