### PR TITLE
fix: avoid error for snippets with a binding but no key directive (#20)

### DIFF
--- a/consult-yasnippet.el
+++ b/consult-yasnippet.el
@@ -154,7 +154,8 @@ this function removes the matching prefix from the preview."
               " ["
               (propertize (or (yas--template-key template)
                               (and (functionp 'yas--template-regexp-key)
-                                   (yas--template-regexp-key template)))
+                                   (yas--template-regexp-key template))
+                              "")
                           'face 'consult-key)
               "]")
              template)))


### PR DESCRIPTION
This PR is to fix #20.
When a snippet has a binding but no key, a propertize error occurred because the key was nil, so I made it fall back to "" instead of nil.
Thank you.
